### PR TITLE
Update to use go-ipfs v0.15.0 (latest)

### DIFF
--- a/endpoints.go
+++ b/endpoints.go
@@ -10,9 +10,9 @@ import (
 	"sort"
 	"strings"
 
-	corecmds "gx/ipfs/QmXporsyf5xMvffd2eiTDoq85dNpYUynGJhfabzDjwP8uR/go-ipfs/core/commands"
-	config "gx/ipfs/QmXporsyf5xMvffd2eiTDoq85dNpYUynGJhfabzDjwP8uR/go-ipfs/repo/config"
-	cmds "gx/ipfs/QmabLouZTZwhfALuBcssPvkzhbYGMb4394huT7HY4LQ6d3/go-ipfs-cmds"
+	cmds "gx/ipfs/QmTjNRVt2fvaRFu93keEC7z5M1GS1iH6qZ9227htQioTUY/go-ipfs-cmds"
+	corecmds "gx/ipfs/QmcKwjeebv5SX3VFUGDFa4BNMYhy14RRaCzQP7JN3UQDpB/go-ipfs/core/commands"
+	config "gx/ipfs/QmcKwjeebv5SX3VFUGDFa4BNMYhy14RRaCzQP7JN3UQDpB/go-ipfs/repo/config"
 	cmdkit "gx/ipfs/QmceUdzxkimdYsgtX733uNgzf1DLHyBKN6ehGSp85ayppM/go-ipfs-cmdkit"
 )
 

--- a/package.json
+++ b/package.json
@@ -13,14 +13,14 @@
       "version": "1.0.0"
     },
     {
-      "hash": "QmabLouZTZwhfALuBcssPvkzhbYGMb4394huT7HY4LQ6d3",
+      "hash": "QmTjNRVt2fvaRFu93keEC7z5M1GS1iH6qZ9227htQioTUY",
       "name": "go-ipfs-cmds",
-      "version": "1.0.8"
+      "version": "1.0.13"
     },
     {
-      "hash": "QmXporsyf5xMvffd2eiTDoq85dNpYUynGJhfabzDjwP8uR",
+      "hash": "QmcKwjeebv5SX3VFUGDFa4BNMYhy14RRaCzQP7JN3UQDpB",
       "name": "go-ipfs",
-      "version": "0.4.14-rc1"
+      "version": "0.4.15"
     }
   ],
   "gxVersion": "0.10.0",


### PR DESCRIPTION
The documentation here is generated by inspecting whatever go-ipfs package is imported, which happens to be out-of date. This updates to the latest (v0.15.0). It also updates go-ipfs-cmds to match in the process.

I needed to do this so I could generate up-to-date info for the new docs site.