### PR TITLE
Fix index links to use `-` separators

### DIFF
--- a/markdown.go
+++ b/markdown.go
@@ -114,7 +114,7 @@ func (md *MarkdownFormatter) GenerateIndex(endps []*Endpoint) string {
 	for _, endp := range endps {
 		fmt.Fprintf(buf, "  *  [%s](#%s)\n",
 			strings.TrimPrefix(endp.Name, "/api/v0"),
-			strings.Replace(endp.Name, "/", "", -1))
+			strings.Replace(strings.TrimPrefix(endp.Name, "/"), "/", "-", -1))
 	}
 
 	buf.WriteString("\n\n## Endpoints\n\n")


### PR DESCRIPTION
The links in the index point to anchors where the `/` are all removed, so a header with the text `/api/v0/add` became a link to `#apiv0add`. However, most markdown systems (including Hugo’s parsing for all out sites) replace the slashes with dashes when generating HTML. This fixes our index links to point to the right place.

Fixes #6.