### PR TITLE
update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@
 In order to build this project, you need to first clone the repo and then run `make install`:
 
 ```sh
-> git clone https://github.com/ipfs/http-api-docs/http-api-docs
-> cd http-api-docs
+> go get https://github.com/ipfs/http-api-docs/http-api-docs
+> cd $GOPATH/src/github.com/ipfs/http-api-docs
 > make install
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@
 
 ## Install
 
-In order to build this project, you need to first clone the repo and then run `make install`:
+In order to build this project, you need to first install Go and then `go get` this repo, finally run `make install`:
 
 ```sh
-> go get https://github.com/ipfs/http-api-docs/http-api-docs
+> go get github.com/ipfs/http-api-docs/http-api-docs
 > cd $GOPATH/src/github.com/ipfs/http-api-docs
 > make install
 ```


### PR DESCRIPTION
I encountered the following error as I tried to install `http-api-docs`

> http-api-docs/main.go:6:2: cannot find package "github.com/ipfs/http-api-docs" in any of:
>         /usr/lib/go/src/github.com/ipfs/http-api-docs (from $GOROOT)
>         /home/e/Workspace/go/src/github.com/ipfs/http-api-docs (from $GOPATH)
> make: *** [Makefile:11: install] Error 1