### PR TITLE
extract json documentation into a separate repo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,11 @@
 module github.com/ipfs/http-api-docs
 
 require (
+	github.com/Stebalien/go-json-doc v0.0.2
+	github.com/ipfs/go-cid v0.0.1
 	github.com/ipfs/go-ipfs v0.4.20
 	github.com/ipfs/go-ipfs-cmdkit v0.0.1
 	github.com/ipfs/go-ipfs-cmds v0.0.5
+	github.com/libp2p/go-libp2p-peer v0.0.1
+	github.com/multiformats/go-multiaddr v0.0.1
 )

--- a/markdown.go
+++ b/markdown.go
@@ -209,7 +209,7 @@ On success, the call to this endpoint will return with 200 and the following bod
 
 `)
 
-	buf.WriteString("```text\n" + response + "\n```\n\n")
+	buf.WriteString("```json\n" + response + "\n```\n\n")
 
 	return buf.String()
 }


### PR DESCRIPTION
So, I wanted to fix a bug where the resulting json objects didn't have commas
between fields. Then I realized this was a _really_ cool library that really
deserved it's own repo so others could ruse it.

So I re-implemented it in a new repo. The new version:

1. Returns valid json objects (for better syntax highlighting).
2. Is extensible. It's now much easier to register custom types.
3. Correctly handles types with MarshalJSON/MarshalText implemented.
4. Handles field tags.
5. Has support for a bunch of built-in types.
6. Correctly documents `[]byte` as `<base64-string>`.
7. Robustly handles recursion without simply setting a recursion limit.
8. Has tests.

Example: https://github.com/Stebalien/go-json-doc/blob/master/examples/example.go

The second commit uses (1) and sets the response language (markdown) to "json".

New output:

<details>
<summary>Output of <code>http-api-docs</code></summary>
<sup>Generated on 2019-04-29, from go-ipfs v0.4.20.</sup>

When an IPFS node is running as a daemon, it exposes an HTTP API that allows
you to control the node and run the same commands you can from the command
line.

In many cases, using this API this is preferable to embedding IPFS directly in
your program — it allows you to maintain peer connections that are longer
lived than your app and you can keep a single IPFS node running instead of
several if your app can be launched multiple times. In fact, the `ipfs`
CLI commands use this API when operating in [online mode]({{< relref
"usage.md#going-online" >}}).

This document is autogenerated from go-ipfs. For issues and support, check out
the [ipfs-http-api-docs](https://github.com/ipfs/ipfs-http-api-docs)
repository on GitHub.

## Getting started

### Alignment with CLI Commands

[Every command](../commands/) usable from the CLI is also available through
the HTTP API. For example:
```sh
> ipfs swarm peers
/ip4/104.131.131.82/tcp/4001/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ
/ip4/104.236.151.122/tcp/4001/ipfs/QmSoLju6m7xTh3DuokvT3886QRYqxAzb1kShaanJgW36yx
/ip4/104.236.176.52/tcp/4001/ipfs/QmSoLnSGccFuZQJzRadHn95W2CrSFmZuTdDWP8HXaHca9z

> curl http://127.0.0.1:5001/api/v0/swarm/peers
{
  "Strings": [
    "/ip4/104.131.131.82/tcp/4001/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ",
    "/ip4/104.236.151.122/tcp/4001/ipfs/QmSoLju6m7xTh3DuokvT3886QRYqxAzb1kShaanJgW36yx",
    "/ip4/104.236.176.52/tcp/4001/ipfs/QmSoLnSGccFuZQJzRadHn95W2CrSFmZuTdDWP8HXaHca9z",
  ]
}
```

### Arguments

Arguments are added through the special query string key "arg":

```
> curl "http://127.0.0.1:5001/api/v0/swarm/disconnect?arg=/ip4/54.93.113.247/tcp/48131/ipfs/QmUDS3nsBD1X4XK5Jo836fed7SErTyTuQzRqWaiQAyBYMP"
{
  "Strings": [
    "disconnect QmUDS3nsBD1X4XK5Jo836fed7SErTyTuQzRqWaiQAyBYMP success",
  ]
}
```

Note that it can be used multiple times to signify multiple arguments.

### Flags

Flags are added through the query string. For example, the `--encoding=json`
flag is the `&encoding=json` query parameter below:

```
> curl "http://127.0.0.1:5001/api/v0/object/get?arg=QmaaqrHyAQm7gALkRW8DcfGX3u8q9rWKnxEMmf7m9z515w&encoding=json"
{
  "Links": [
    {
      "Name": "index.html",
      "Hash": "QmYftndCvcEiuSZRX7njywX2AGSeHY2ASa7VryCq1mKwEw",
      "Size": 1700
    },
    {
      "Name": "static",
      "Hash": "QmdtWFiasJeh2ymW3TD2cLHYxn1ryTuWoNpwieFyJriGTS",
      "Size": 2428803
    }
  ],
  "Data": "CAE="
}
```

### /api/v0/add

Add a file or directory to ipfs.


#### Arguments

  - `arg` [file]: The path to a file to be added to ipfs. Required: **yes**.
  - `recursive` [bool]: Add directory paths recursively. Required: no.
  - `dereference-args` [bool]: Symlinks supplied in arguments are dereferenced. Required: no.
  - `stdin-name` [string]: Assign a name if the file source is stdin. Required: no.
  - `hidden` [bool]: Include files that are hidden. Only takes effect on recursive add. Required: no.
  - `quiet` [bool]: Write minimal output. Required: no.
  - `quieter` [bool]: Write only final hash. Required: no.
  - `silent` [bool]: Write no output. Required: no.
  - `progress` [bool]: Stream progress data. Required: no.
  - `trickle` [bool]: Use trickle-dag format for dag generation. Required: no.
  - `only-hash` [bool]: Only chunk and hash - do not write to disk. Required: no.
  - `wrap-with-directory` [bool]: Wrap files with a directory object. Required: no.
  - `chunker` [string]: Chunking algorithm, size-[bytes] or rabin-[min]-[avg]-[max]. Default: "size-262144". Required: no.
  - `pin` [bool]: Pin this object when adding. Default: "true". Required: no.
  - `raw-leaves` [bool]: Use raw blocks for leaf nodes. (experimental). Required: no.
  - `nocopy` [bool]: Add the file using filestore. Implies raw-leaves. (experimental). Required: no.
  - `fscache` [bool]: Check the filestore for pre-existing blocks. (experimental). Required: no.
  - `cid-version` [int]: CID version. Defaults to 0 unless an option that depends on CIDv1 is passed. (experimental). Required: no.
  - `hash` [string]: Hash function to use. Implies CIDv1 if not sha2-256. (experimental). Default: "sha2-256". Required: no.
  - `inline` [bool]: Inline small blocks into CIDs. (experimental). Required: no.
  - `inline-limit` [int]: Maximum block size to inline. (experimental). Default: "32". Required: no.


#### Request Body

Argument "path" is of file type. This endpoint expects a file in the body of the request as 'multipart/form-data'.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Bytes": "<int64>",
  "Hash": "<string>",
  "Name": "<string>",
  "Size": "<string>"
}

```

#### cURL Example

`curl -F file=@myfile "http://localhost:5001/api/v0/add?recursive=<value>&dereference-args=<value>&stdin-name=<value>&hidden=<value>&quiet=<value>&quieter=<value>&silent=<value>&progress=<value>&trickle=<value>&only-hash=<value>&wrap-with-directory=<value>&chunker=size-262144&pin=true&raw-leaves=<value>&nocopy=<value>&fscache=<value>&cid-version=<value>&hash=sha2-256&inline=<value>&inline-limit=32"`

***

### /api/v0/bitswap/ledger

Show the current ledger for a peer.


#### Arguments

  - `arg` [string]: The PeerID (B58) of the ledger to inspect. Required: **yes**.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Exchanged": "<uint64>",
  "Peer": "<string>",
  "Recv": "<uint64>",
  "Sent": "<uint64>",
  "Value": "<float64>"
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/bitswap/ledger?arg=<peer>"`

***

### /api/v0/bitswap/reprovide

Trigger reprovider.


#### Arguments

This endpoint takes no arguments.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
This endpoint returns a `text/plain` response body.
```

#### cURL Example

`curl "http://localhost:5001/api/v0/bitswap/reprovide"`

***

### /api/v0/bitswap/stat

Show some diagnostic information on the bitswap agent.


#### Arguments

  - `verbose` [bool]: Print extra information. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "BlocksReceived": "<uint64>",
  "BlocksSent": "<uint64>",
  "DataReceived": "<uint64>",
  "DataSent": "<uint64>",
  "DupBlksReceived": "<uint64>",
  "DupDataReceived": "<uint64>",
  "MessagesReceived": "<uint64>",
  "Peers": [
    "<string>"
  ],
  "ProvideBufLen": "<int>",
  "Wantlist": [
    {
      "/": "<cid-string>"
    }
  ]
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/bitswap/stat?verbose=<value>"`

***

### /api/v0/bitswap/wantlist

Show blocks currently on the wantlist.


#### Arguments

  - `peer` [string]: Specify which peer to show wantlist for. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Keys": [
    {
      "/": "<cid-string>"
    }
  ]
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/bitswap/wantlist?peer=<value>"`

***

### /api/v0/block/get

Get a raw IPFS block.


#### Arguments

  - `arg` [string]: The base58 multihash of an existing block to get. Required: **yes**.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
This endpoint returns a `text/plain` response body.
```

#### cURL Example

`curl "http://localhost:5001/api/v0/block/get?arg=<key>"`

***

### /api/v0/block/put

Store input as an IPFS block.


#### Arguments

  - `arg` [file]: The data to be stored as an IPFS block. Required: **yes**.
  - `format` [string]: cid format for blocks to be created with. Required: no.
  - `mhtype` [string]: multihash hash function. Default: "sha2-256". Required: no.
  - `mhlen` [int]: multihash hash length. Default: "-1". Required: no.
  - `pin` [bool]: pin added blocks recursively. Default: "false". Required: no.


#### Request Body

Argument "data" is of file type. This endpoint expects a file in the body of the request as 'multipart/form-data'.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Key": "<string>",
  "Size": "<int>"
}

```

#### cURL Example

`curl -F file=@myfile "http://localhost:5001/api/v0/block/put?format=<value>&mhtype=sha2-256&mhlen=-1&pin=false"`

***

### /api/v0/block/rm

Remove IPFS block(s).


#### Arguments

  - `arg` [string]: Bash58 encoded multihash of block(s) to remove. Required: **yes**.
  - `force` [bool]: Ignore nonexistent blocks. Required: no.
  - `quiet` [bool]: Write minimal output. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Error": "<string>",
  "Hash": "<string>"
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/block/rm?arg=<hash>&force=<value>&quiet=<value>"`

***

### /api/v0/block/stat

Print information of a raw IPFS block.


#### Arguments

  - `arg` [string]: The base58 multihash of an existing block to stat. Required: **yes**.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Key": "<string>",
  "Size": "<int>"
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/block/stat?arg=<key>"`

***

### /api/v0/bootstrap

Show or edit the list of bootstrap peers.


#### Arguments

This endpoint takes no arguments.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Peers": [
    "<string>"
  ]
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/bootstrap"`

***

### /api/v0/bootstrap/add

Add peers to the bootstrap list.


#### Arguments

  - `arg` [string]: A peer to add to the bootstrap list (in the format '<multiaddr>/<peerID>') Required: no.
  - `default` [bool]: Add default bootstrap nodes. (Deprecated, use 'default' subcommand instead). Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Peers": [
    "<string>"
  ]
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/bootstrap/add?arg=<peer>&default=<value>"`

***

### /api/v0/bootstrap/add/default

Add default peers to the bootstrap list.


#### Arguments

This endpoint takes no arguments.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Peers": [
    "<string>"
  ]
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/bootstrap/add/default"`

***

### /api/v0/bootstrap/list

Show peers in the bootstrap list.


#### Arguments

This endpoint takes no arguments.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Peers": [
    "<string>"
  ]
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/bootstrap/list"`

***

### /api/v0/bootstrap/rm

Remove peers from the bootstrap list.


#### Arguments

  - `arg` [string]: A peer to add to the bootstrap list (in the format '<multiaddr>/<peerID>') Required: no.
  - `all` [bool]: Remove all bootstrap peers. (Deprecated, use 'all' subcommand). Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Peers": [
    "<string>"
  ]
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/bootstrap/rm?arg=<peer>&all=<value>"`

***

### /api/v0/bootstrap/rm/all

Remove all peers from the bootstrap list.


#### Arguments

This endpoint takes no arguments.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Peers": [
    "<string>"
  ]
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/bootstrap/rm/all"`

***

### /api/v0/cat

Show IPFS object data.


#### Arguments

  - `arg` [string]: The path to the IPFS object(s) to be outputted. Required: **yes**.
  - `offset` [int64]: Byte offset to begin reading from. Required: no.
  - `length` [int64]: Maximum number of bytes to read. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
This endpoint returns a `text/plain` response body.
```

#### cURL Example

`curl "http://localhost:5001/api/v0/cat?arg=<ipfs-path>&offset=<value>&length=<value>"`

***

### /api/v0/cid/base32

Convert CIDs to Base32 CID version 1.


#### Arguments

  - `arg` [string]: Cids to convert. Required: **yes**.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "CidStr": "<string>",
  "ErrorMsg": "<string>",
  "Formatted": "<string>"
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/cid/base32?arg=<cid>"`

***

### /api/v0/cid/bases

List available multibase encodings.


#### Arguments

  - `prefix` [bool]: also include the single leter prefixes in addition to the code. Required: no.
  - `numeric` [bool]: also include numeric codes. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
[
  {
    "Code": "<int>",
    "Name": "<string>"
  }
]

```

#### cURL Example

`curl "http://localhost:5001/api/v0/cid/bases?prefix=<value>&numeric=<value>"`

***

### /api/v0/cid/codecs

List available CID codecs.


#### Arguments

  - `numeric` [bool]: also include numeric codes. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
[
  {
    "Code": "<int>",
    "Name": "<string>"
  }
]

```

#### cURL Example

`curl "http://localhost:5001/api/v0/cid/codecs?numeric=<value>"`

***

### /api/v0/cid/format

Format and convert a CID in various useful ways.


#### Arguments

  - `arg` [string]: Cids to format. Required: **yes**.
  - `f` [string]: Printf style format string. Default: %!s(MISSING). Default: "%!s(MISSING)". Required: no.
  - `v` [string]: CID version to convert to. Required: no.
  - `b` [string]: Multibase to display CID in. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "CidStr": "<string>",
  "ErrorMsg": "<string>",
  "Formatted": "<string>"
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/cid/format?arg=<cid>&f=%s&v=<value>&b=<value>"`

***

### /api/v0/cid/hashes

List available multihashes.


#### Arguments

  - `numeric` [bool]: also include numeric codes. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
[
  {
    "Code": "<int>",
    "Name": "<string>"
  }
]

```

#### cURL Example

`curl "http://localhost:5001/api/v0/cid/hashes?numeric=<value>"`

***

### /api/v0/commands

List all available commands.


#### Arguments

  - `flags` [bool]: Show command flags. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Name": "<string>",
  "Options": [
    {
      "Names": [
        "<string>"
      ]
    }
  ],
  "Subcommands": [
    {
      "Name": "<string>",
      "Options": [
        {
          "Names": [
            "<string>"
          ]
        }
      ],
      "Subcommands": [
        "..."
      ]
    }
  ]
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/commands?flags=<value>"`

***

### /api/v0/config

Get and set ipfs config values.


#### Arguments

  - `arg` [string]: The key of the config entry (e.g. "Addresses.API"). Required: **yes**.
  - `arg` [string]: The value to set the config entry to. Required: no.
  - `bool` [bool]: Set a boolean value. Required: no.
  - `json` [bool]: Parse stringified JSON. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Key": "<string>",
  "Value": "<object>"
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/config?arg=<key>&arg=<value>&bool=<value>&json=<value>"`

***

### /api/v0/config/edit

Open the config file for editing in $EDITOR.


#### Arguments

This endpoint takes no arguments.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
This endpoint returns a `text/plain` response body.
```

#### cURL Example

`curl "http://localhost:5001/api/v0/config/edit"`

***

### /api/v0/config/profile/apply

Apply profile to config.


#### Arguments

  - `arg` [string]: The profile to apply to the config. Required: **yes**.
  - `dry-run` [bool]: print difference between the current config and the config that would be generated. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "NewCfg": {
    "<string>": "<object>"
  },
  "OldCfg": {
    "<string>": "<object>"
  }
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/config/profile/apply?arg=<profile>&dry-run=<value>"`

***

### /api/v0/config/replace

Replace the config with <file>.


#### Arguments

  - `arg` [file]: The file to use as the new config. Required: **yes**.


#### Request Body

Argument "file" is of file type. This endpoint expects a file in the body of the request as 'multipart/form-data'.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
This endpoint returns a `text/plain` response body.
```

#### cURL Example

`curl -F file=@myfile "http://localhost:5001/api/v0/config/replace"`

***

### /api/v0/config/show

Output config file contents.


#### Arguments

This endpoint takes no arguments.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "<string>": "<object>"
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/config/show"`

***

### /api/v0/dag/get

Get a dag node from ipfs.


#### Arguments

  - `arg` [string]: The object to get Required: **yes**.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
This endpoint returns a `text/plain` response body.
```

#### cURL Example

`curl "http://localhost:5001/api/v0/dag/get?arg=<ref>"`

***

### /api/v0/dag/put

Add a dag node to ipfs.


#### Arguments

  - `arg` [file]: The object to put Required: **yes**.
  - `format` [string]: Format that the object will be added as. Default: "cbor". Required: no.
  - `input-enc` [string]: Format that the input object will be. Default: "json". Required: no.
  - `pin` [bool]: Pin this object when adding. Required: no.
  - `hash` [string]: Hash function to use. Default: . Required: no.


#### Request Body

Argument "object data" is of file type. This endpoint expects a file in the body of the request as 'multipart/form-data'.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Cid": {
    "/": "<cid-string>"
  }
}

```

#### cURL Example

`curl -F file=@myfile "http://localhost:5001/api/v0/dag/put?format=cbor&input-enc=json&pin=<value>&hash=<value>"`

***

### /api/v0/dag/resolve

Resolve ipld block


#### Arguments

  - `arg` [string]: The path to resolve Required: **yes**.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Cid": {
    "/": "<cid-string>"
  },
  "RemPath": "<string>"
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/dag/resolve?arg=<ref>"`

***

### /api/v0/dht/findpeer

Find the multiaddresses associated with a Peer ID.


#### Arguments

  - `arg` [string]: The ID of the peer to search for. Required: **yes**.
  - `verbose` [bool]: Print extra information. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Extra": "<string>",
  "ID": "<peer-id>",
  "Responses": [
    "<object>"
  ],
  "Type": "<int>"
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/dht/findpeer?arg=<peerID>&verbose=<value>"`

***

### /api/v0/dht/findprovs

Find peers that can provide a specific value, given a key.


#### Arguments

  - `arg` [string]: The key to find providers for. Required: **yes**.
  - `verbose` [bool]: Print extra information. Required: no.
  - `num-providers` [int]: The number of providers to find. Default: "20". Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Extra": "<string>",
  "ID": "<peer-id>",
  "Responses": [
    "<object>"
  ],
  "Type": "<int>"
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/dht/findprovs?arg=<key>&verbose=<value>&num-providers=20"`

***

### /api/v0/dht/get

Given a key, query the routing system for its best value.


#### Arguments

  - `arg` [string]: The key to find a value for. Required: **yes**.
  - `verbose` [bool]: Print extra information. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Extra": "<string>",
  "ID": "<peer-id>",
  "Responses": [
    "<object>"
  ],
  "Type": "<int>"
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/dht/get?arg=<key>&verbose=<value>"`

***

### /api/v0/dht/provide

Announce to the network that you are providing given values.


#### Arguments

  - `arg` [string]: The key[s] to send provide records for. Required: **yes**.
  - `verbose` [bool]: Print extra information. Required: no.
  - `recursive` [bool]: Recursively provide entire graph. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Extra": "<string>",
  "ID": "<peer-id>",
  "Responses": [
    "<object>"
  ],
  "Type": "<int>"
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/dht/provide?arg=<key>&verbose=<value>&recursive=<value>"`

***

### /api/v0/dht/put

Write a key/value pair to the routing system.


#### Arguments

  - `arg` [string]: The key to store the value at. Required: **yes**.
  - `arg` [string]: The value to store. Required: **yes**.
  - `verbose` [bool]: Print extra information. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Extra": "<string>",
  "ID": "<peer-id>",
  "Responses": [
    "<object>"
  ],
  "Type": "<int>"
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/dht/put?arg=<key>&arg=<value>&verbose=<value>"`

***

### /api/v0/dht/query

Find the closest Peer IDs to a given Peer ID by querying the DHT.


#### Arguments

  - `arg` [string]: The peerID to run the query against. Required: **yes**.
  - `verbose` [bool]: Print extra information. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Extra": "<string>",
  "ID": "<peer-id>",
  "Responses": [
    "<object>"
  ],
  "Type": "<int>"
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/dht/query?arg=<peerID>&verbose=<value>"`

***

### /api/v0/diag/cmds

List commands run on this IPFS node.


#### Arguments

  - `verbose` [bool]: Print extra information. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
[
  {
    "Active": "<bool>",
    "Args": [
      "<string>"
    ],
    "Command": "<string>",
    "EndTime": "<timestamp>",
    "ID": "<int>",
    "Options": {
      "<string>": "<object>"
    },
    "StartTime": "<timestamp>"
  }
]

```

#### cURL Example

`curl "http://localhost:5001/api/v0/diag/cmds?verbose=<value>"`

***

### /api/v0/diag/cmds/clear

Clear inactive requests from the log.


#### Arguments

This endpoint takes no arguments.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
This endpoint returns a `text/plain` response body.
```

#### cURL Example

`curl "http://localhost:5001/api/v0/diag/cmds/clear"`

***

### /api/v0/diag/cmds/set-time

Set how long to keep inactive requests in the log.


#### Arguments

  - `arg` [string]: Time to keep inactive requests in log. Required: **yes**.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
This endpoint returns a `text/plain` response body.
```

#### cURL Example

`curl "http://localhost:5001/api/v0/diag/cmds/set-time?arg=<time>"`

***

### /api/v0/diag/sys

Print system diagnostic information.


#### Arguments

This endpoint takes no arguments.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
This endpoint returns a `text/plain` response body.
```

#### cURL Example

`curl "http://localhost:5001/api/v0/diag/sys"`

***

### /api/v0/dns

Resolve DNS links.


#### Arguments

  - `arg` [string]: The domain-name name to resolve. Required: **yes**.
  - `recursive` [bool]: Resolve until the result is not a DNS link. Default: "true". Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Path": "<string>"
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/dns?arg=<domain-name>&recursive=true"`

***

### /api/v0/file/ls

List directory contents for Unix filesystem objects.


#### Arguments

  - `arg` [string]: The path to the IPFS object(s) to list links from. Required: **yes**.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Arguments": {
    "<string>": "<string>"
  },
  "Objects": {
    "<string>": {
      "Hash": "<string>",
      "Links": [
        {
          "Hash": "<string>",
          "Name": "<string>",
          "Size": "<uint64>",
          "Type": "<string>"
        }
      ],
      "Size": "<uint64>",
      "Type": "<string>"
    }
  }
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/file/ls?arg=<ipfs-path>"`

***

### /api/v0/files/chcid

Change the cid version or hash function of the root node of a given path.


#### Arguments

  - `arg` [string]: Path to change. Default: '/'. Required: no.
  - `cid-version` [int]: Cid version to use. (experimental). Required: no.
  - `hash` [string]: Hash function to use. Will set Cid version to 1 if used. (experimental). Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
This endpoint returns a `text/plain` response body.
```

#### cURL Example

`curl "http://localhost:5001/api/v0/files/chcid?arg=<path>&cid-version=<value>&hash=<value>"`

***

### /api/v0/files/cp

Copy files into mfs.


#### Arguments

  - `arg` [string]: Source object to copy. Required: **yes**.
  - `arg` [string]: Destination to copy object to. Required: **yes**.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
This endpoint returns a `text/plain` response body.
```

#### cURL Example

`curl "http://localhost:5001/api/v0/files/cp?arg=<source>&arg=<dest>"`

***

### /api/v0/files/flush

Flush a given path's data to disk.


#### Arguments

  - `arg` [string]: Path to flush. Default: '/'. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Cid": "<string>"
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/files/flush?arg=<path>"`

***

### /api/v0/files/ls

List directories in the local mutable namespace.


#### Arguments

  - `arg` [string]: Path to show listing for. Defaults to '/'. Required: no.
  - `l` [bool]: Use long listing format. Required: no.
  - `U` [bool]: Do not sort; list entries in directory order. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Entries": [
    {
      "Hash": "<string>",
      "Name": "<string>",
      "Size": "<int64>",
      "Type": "<int>"
    }
  ]
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/files/ls?arg=<path>&l=<value>&U=<value>"`

***

### /api/v0/files/mkdir

Make directories.


#### Arguments

  - `arg` [string]: Path to dir to make. Required: **yes**.
  - `parents` [bool]: No error if existing, make parent directories as needed. Required: no.
  - `cid-version` [int]: Cid version to use. (experimental). Required: no.
  - `hash` [string]: Hash function to use. Will set Cid version to 1 if used. (experimental). Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
This endpoint returns a `text/plain` response body.
```

#### cURL Example

`curl "http://localhost:5001/api/v0/files/mkdir?arg=<path>&parents=<value>&cid-version=<value>&hash=<value>"`

***

### /api/v0/files/mv

Move files.


#### Arguments

  - `arg` [string]: Source file to move. Required: **yes**.
  - `arg` [string]: Destination path for file to be moved to. Required: **yes**.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
This endpoint returns a `text/plain` response body.
```

#### cURL Example

`curl "http://localhost:5001/api/v0/files/mv?arg=<source>&arg=<dest>"`

***

### /api/v0/files/read

Read a file in a given mfs.


#### Arguments

  - `arg` [string]: Path to file to be read. Required: **yes**.
  - `offset` [int64]: Byte offset to begin reading from. Required: no.
  - `count` [int64]: Maximum number of bytes to read. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
This endpoint returns a `text/plain` response body.
```

#### cURL Example

`curl "http://localhost:5001/api/v0/files/read?arg=<path>&offset=<value>&count=<value>"`

***

### /api/v0/files/rm

Remove a file.


#### Arguments

  - `arg` [string]: File to remove. Required: **yes**.
  - `recursive` [bool]: Recursively remove directories. Required: no.
  - `force` [bool]: Forcibly remove target at path; implies -r for directories. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
This endpoint returns a `text/plain` response body.
```

#### cURL Example

`curl "http://localhost:5001/api/v0/files/rm?arg=<path>&recursive=<value>&force=<value>"`

***

### /api/v0/files/stat

Display file status.


#### Arguments

  - `arg` [string]: Path to node to stat. Required: **yes**.
  - `format` [string]: Print statistics in given format. Allowed tokens: <hash> <size> <cumulsize> <type> <childs>. Conflicts with other format options. Default: <hash>
Size: <size>
CumulativeSize: <cumulsize>
ChildBlocks: <childs>
Type: <type>. Default: "<hash>
Size: <size>
CumulativeSize: <cumulsize>
ChildBlocks: <childs>
Type: <type>". Required: no.
  - `hash` [bool]: Print only hash. Implies '--format=<hash>'. Conflicts with other format options. Required: no.
  - `size` [bool]: Print only size. Implies '--format=<cumulsize>'. Conflicts with other format options. Required: no.
  - `with-local` [bool]: Compute the amount of the dag that is local, and if possible the total size. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Blocks": "<int>",
  "CumulativeSize": "<uint64>",
  "Hash": "<string>",
  "Local": "<bool>",
  "Size": "<uint64>",
  "SizeLocal": "<uint64>",
  "Type": "<string>",
  "WithLocality": "<bool>"
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/files/stat?arg=<path>&format=<hash>
Size: <size>
CumulativeSize: <cumulsize>
ChildBlocks: <childs>
Type: <type>&hash=<value>&size=<value>&with-local=<value>"`

***

### /api/v0/files/write

Write to a mutable file in a given filesystem.


#### Arguments

  - `arg` [string]: Path to write to. Required: **yes**.
  - `arg` [file]: Data to write. Required: **yes**.
  - `offset` [int64]: Byte offset to begin writing at. Required: no.
  - `create` [bool]: Create the file if it does not exist. Required: no.
  - `parents` [bool]: Make parent directories as needed. Required: no.
  - `truncate` [bool]: Truncate the file to size zero before writing. Required: no.
  - `count` [int64]: Maximum number of bytes to read. Required: no.
  - `raw-leaves` [bool]: Use raw blocks for newly created leaf nodes. (experimental). Required: no.
  - `cid-version` [int]: Cid version to use. (experimental). Required: no.
  - `hash` [string]: Hash function to use. Will set Cid version to 1 if used. (experimental). Required: no.


#### Request Body

Argument "data" is of file type. This endpoint expects a file in the body of the request as 'multipart/form-data'.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
This endpoint returns a `text/plain` response body.
```

#### cURL Example

`curl -F file=@myfile "http://localhost:5001/api/v0/files/write?arg=<path>&offset=<value>&create=<value>&parents=<value>&truncate=<value>&count=<value>&raw-leaves=<value>&cid-version=<value>&hash=<value>"`

***

### /api/v0/filestore/dups

List blocks that are both in the filestore and standard block storage.


#### Arguments

This endpoint takes no arguments.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Err": "<string>",
  "Ref": "<string>"
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/filestore/dups"`

***

### /api/v0/filestore/ls

List objects in filestore.


#### Arguments

  - `arg` [string]: Cid of objects to list. Required: no.
  - `file-order` [bool]: sort the results based on the path of the backing file. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "ErrorMsg": "<string>",
  "FilePath": "<string>",
  "Key": {
    "/": "<cid-string>"
  },
  "Offset": "<uint64>",
  "Size": "<uint64>",
  "Status": "<int32>"
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/filestore/ls?arg=<obj>&file-order=<value>"`

***

### /api/v0/filestore/verify

Verify objects in filestore.


#### Arguments

  - `arg` [string]: Cid of objects to verify. Required: no.
  - `file-order` [bool]: verify the objects based on the order of the backing file. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "ErrorMsg": "<string>",
  "FilePath": "<string>",
  "Key": {
    "/": "<cid-string>"
  },
  "Offset": "<uint64>",
  "Size": "<uint64>",
  "Status": "<int32>"
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/filestore/verify?arg=<obj>&file-order=<value>"`

***

### /api/v0/get

Download IPFS objects.


#### Arguments

  - `arg` [string]: The path to the IPFS object(s) to be outputted. Required: **yes**.
  - `output` [string]: The path where the output should be stored. Required: no.
  - `archive` [bool]: Output a TAR archive. Required: no.
  - `compress` [bool]: Compress the output with GZIP compression. Required: no.
  - `compression-level` [int]: The level of compression (1-9). Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
This endpoint returns a `text/plain` response body.
```

#### cURL Example

`curl "http://localhost:5001/api/v0/get?arg=<ipfs-path>&output=<value>&archive=<value>&compress=<value>&compression-level=<value>"`

***

### /api/v0/id

Show ipfs node id info.


#### Arguments

  - `arg` [string]: Peer.ID of node to look up. Required: no.
  - `format` [string]: Optional output format. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Addresses": [
    "<string>"
  ],
  "AgentVersion": "<string>",
  "ID": "<string>",
  "ProtocolVersion": "<string>",
  "PublicKey": "<string>"
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/id?arg=<peerid>&format=<value>"`

***

### /api/v0/key/gen

Create a new keypair


#### Arguments

  - `arg` [string]: name of key to create Required: **yes**.
  - `type` [string]: type of the key to create [rsa, ed25519]. Required: no.
  - `size` [int]: size of the key to generate. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Id": "<string>",
  "Name": "<string>"
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/key/gen?arg=<name>&type=<value>&size=<value>"`

***

### /api/v0/key/list

List all local keypairs


#### Arguments

  - `l` [bool]: Show extra information about keys. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Keys": [
    {
      "Id": "<string>",
      "Name": "<string>"
    }
  ]
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/key/list?l=<value>"`

***

### /api/v0/key/rename

Rename a keypair


#### Arguments

  - `arg` [string]: name of key to rename Required: **yes**.
  - `arg` [string]: new name of the key Required: **yes**.
  - `force` [bool]: Allow to overwrite an existing key. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Id": "<string>",
  "Now": "<string>",
  "Overwrite": "<bool>",
  "Was": "<string>"
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/key/rename?arg=<name>&arg=<newName>&force=<value>"`

***

### /api/v0/key/rm

Remove a keypair


#### Arguments

  - `arg` [string]: names of keys to remove Required: **yes**.
  - `l` [bool]: Show extra information about keys. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Keys": [
    {
      "Id": "<string>",
      "Name": "<string>"
    }
  ]
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/key/rm?arg=<name>&l=<value>"`

***

### /api/v0/log/level

Change the logging level.


#### Arguments

  - `arg` [string]: The subsystem logging identifier. Use 'all' for all subsystems. Required: **yes**.
  - `arg` [string]: The log level, with 'debug' the most verbose and 'critical' the least verbose.
			One of: debug, info, warning, error, critical.
		 Required: **yes**.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Message": "<string>"
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/log/level?arg=<subsystem>&arg=<level>"`

***

### /api/v0/log/ls

List the logging subsystems.


#### Arguments

This endpoint takes no arguments.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Strings": [
    "<string>"
  ]
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/log/ls"`

***

### /api/v0/log/tail

Read the event log.


#### Arguments

This endpoint takes no arguments.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
This endpoint returns a `text/plain` response body.
```

#### cURL Example

`curl "http://localhost:5001/api/v0/log/tail"`

***

### /api/v0/ls

List directory contents for Unix filesystem objects.


#### Arguments

  - `arg` [string]: The path to the IPFS object(s) to list links from. Required: **yes**.
  - `headers` [bool]: Print table headers (Hash, Size, Name). Required: no.
  - `resolve-type` [bool]: Resolve linked objects to find out their types. Default: "true". Required: no.
  - `size` [bool]: Resolve linked objects to find out their file size. Default: "true". Required: no.
  - `stream` [bool]: Enable exprimental streaming of directory entries as they are traversed. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Objects": [
    {
      "Hash": "<string>",
      "Links": [
        {
          "Hash": "<string>",
          "Name": "<string>",
          "Size": "<uint64>",
          "Target": "<string>",
          "Type": "<int32>"
        }
      ]
    }
  ]
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/ls?arg=<ipfs-path>&headers=<value>&resolve-type=true&size=true&stream=<value>"`

***

### /api/v0/mount

Mounts IPFS to the filesystem (read-only).


#### Arguments

  - `ipfs-path` [string]: The path where IPFS should be mounted. Required: no.
  - `ipns-path` [string]: The path where IPNS should be mounted. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "FuseAllowOther": "<bool>",
  "IPFS": "<string>",
  "IPNS": "<string>"
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/mount?ipfs-path=<value>&ipns-path=<value>"`

***

### /api/v0/name/publish

Publish IPNS names.


#### Arguments

  - `arg` [string]: ipfs path of the object to be published. Required: **yes**.
  - `resolve` [bool]: Check if the given path can be resolved before publishing. Default: "true". Required: no.
  - `lifetime` [string]: Time duration that the record will be valid for.
    This accepts durations such as "300s", "1.5h" or "2h45m". Valid time units are
    "ns", "us" (or "µs"), "ms", "s", "m", "h". Default: "24h". Required: no.
  - `allow-offline` [bool]: When offline, save the IPNS record to the the local datastore without broadcasting to the network instead of simply failing. Required: no.
  - `ttl` [string]: Time duration this record should be cached for. Uses the same syntax as the lifetime option. (caution: experimental). Required: no.
  - `key` [string]: Name of the key to be used or a valid PeerID, as listed by 'ipfs key list -l'. Default: "self". Required: no.
  - `quieter` [bool]: Write only final hash. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Name": "<string>",
  "Value": "<string>"
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/name/publish?arg=<ipfs-path>&resolve=true&lifetime=24h&allow-offline=<value>&ttl=<value>&key=self&quieter=<value>"`

***

### /api/v0/name/pubsub/cancel

Cancel a name subscription


#### Arguments

  - `arg` [string]: Name to cancel the subscription for. Required: **yes**.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Canceled": "<bool>"
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/name/pubsub/cancel?arg=<name>"`

***

### /api/v0/name/pubsub/state

Query the state of IPNS pubsub


#### Arguments

This endpoint takes no arguments.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Enabled": "<bool>"
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/name/pubsub/state"`

***

### /api/v0/name/pubsub/subs

Show current name subscriptions


#### Arguments

This endpoint takes no arguments.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Strings": [
    "<string>"
  ]
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/name/pubsub/subs"`

***

### /api/v0/name/resolve

Resolve IPNS names.


#### Arguments

  - `arg` [string]: The IPNS name to resolve. Defaults to your node's peerID. Required: no.
  - `recursive` [bool]: Resolve until the result is not an IPNS name. Default: "true". Required: no.
  - `nocache` [bool]: Do not use cached entries. Required: no.
  - `dht-record-count` [uint]: Number of records to request for DHT resolution. Required: no.
  - `dht-timeout` [string]: Max time to collect values during DHT resolution eg "30s". Pass 0 for no timeout. Required: no.
  - `stream` [bool]: Stream entries as they are found. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Path": "<string>"
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/name/resolve?arg=<name>&recursive=true&nocache=<value>&dht-record-count=<value>&dht-timeout=<value>&stream=<value>"`

***

### /api/v0/object/data

Output the raw bytes of an IPFS object.


#### Arguments

  - `arg` [string]: Key of the object to retrieve, in base58-encoded multihash format. Required: **yes**.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
This endpoint returns a `text/plain` response body.
```

#### cURL Example

`curl "http://localhost:5001/api/v0/object/data?arg=<key>"`

***

### /api/v0/object/diff

Display the diff between two ipfs objects.


#### Arguments

  - `arg` [string]: Object to diff against. Required: **yes**.
  - `arg` [string]: Object to diff. Required: **yes**.
  - `verbose` [bool]: Print extra information. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Changes": [
    {
      "After": {
        "/": "<cid-string>"
      },
      "Before": {
        "/": "<cid-string>"
      },
      "Path": "<string>",
      "Type": "<int>"
    }
  ]
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/object/diff?arg=<obj_a>&arg=<obj_b>&verbose=<value>"`

***

### /api/v0/object/get

Get and serialize the DAG node named by <key>.


#### Arguments

  - `arg` [string]: Key of the object to retrieve, in base58-encoded multihash format. Required: **yes**.
  - `data-encoding` [string]: Encoding type of the data field, either "text" or "base64". Default: "text". Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Data": "<string>",
  "Links": [
    {
      "Hash": "<string>",
      "Name": "<string>",
      "Size": "<uint64>"
    }
  ]
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/object/get?arg=<key>&data-encoding=text"`

***

### /api/v0/object/links

Output the links pointed to by the specified object.


#### Arguments

  - `arg` [string]: Key of the object to retrieve, in base58-encoded multihash format. Required: **yes**.
  - `headers` [bool]: Print table headers (Hash, Size, Name). Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Hash": "<string>",
  "Links": [
    {
      "Hash": "<string>",
      "Name": "<string>",
      "Size": "<uint64>"
    }
  ]
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/object/links?arg=<key>&headers=<value>"`

***

### /api/v0/object/new

Create a new object from an ipfs template.


#### Arguments

  - `arg` [string]: Template to use. Optional. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Hash": "<string>",
  "Links": [
    {
      "Hash": "<string>",
      "Name": "<string>",
      "Size": "<uint64>"
    }
  ]
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/object/new?arg=<template>"`

***

### /api/v0/object/patch/add-link

Add a link to a given object.


#### Arguments

  - `arg` [string]: The hash of the node to modify. Required: **yes**.
  - `arg` [string]: Name of link to create. Required: **yes**.
  - `arg` [string]: IPFS object to add link to. Required: **yes**.
  - `create` [bool]: Create intermediary nodes. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Hash": "<string>",
  "Links": [
    {
      "Hash": "<string>",
      "Name": "<string>",
      "Size": "<uint64>"
    }
  ]
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/object/patch/add-link?arg=<root>&arg=<name>&arg=<ref>&create=<value>"`

***

### /api/v0/object/patch/append-data

Append data to the data segment of a dag node.


#### Arguments

  - `arg` [string]: The hash of the node to modify. Required: **yes**.
  - `arg` [file]: Data to append. Required: **yes**.


#### Request Body

Argument "data" is of file type. This endpoint expects a file in the body of the request as 'multipart/form-data'.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Hash": "<string>",
  "Links": [
    {
      "Hash": "<string>",
      "Name": "<string>",
      "Size": "<uint64>"
    }
  ]
}

```

#### cURL Example

`curl -F file=@myfile "http://localhost:5001/api/v0/object/patch/append-data?arg=<root>"`

***

### /api/v0/object/patch/rm-link

Remove a link from a given object.


#### Arguments

  - `arg` [string]: The hash of the node to modify. Required: **yes**.
  - `arg` [string]: Name of the link to remove. Required: **yes**.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Hash": "<string>",
  "Links": [
    {
      "Hash": "<string>",
      "Name": "<string>",
      "Size": "<uint64>"
    }
  ]
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/object/patch/rm-link?arg=<root>&arg=<name>"`

***

### /api/v0/object/patch/set-data

Set the data field of an IPFS object.


#### Arguments

  - `arg` [string]: The hash of the node to modify. Required: **yes**.
  - `arg` [file]: The data to set the object to. Required: **yes**.


#### Request Body

Argument "data" is of file type. This endpoint expects a file in the body of the request as 'multipart/form-data'.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Hash": "<string>",
  "Links": [
    {
      "Hash": "<string>",
      "Name": "<string>",
      "Size": "<uint64>"
    }
  ]
}

```

#### cURL Example

`curl -F file=@myfile "http://localhost:5001/api/v0/object/patch/set-data?arg=<root>"`

***

### /api/v0/object/put

Store input as a DAG object, print its key.


#### Arguments

  - `arg` [file]: Data to be stored as a DAG object. Required: **yes**.
  - `inputenc` [string]: Encoding type of input data. One of: {"protobuf", "json"}. Default: "json". Required: no.
  - `datafieldenc` [string]: Encoding type of the data field, either "text" or "base64". Default: "text". Required: no.
  - `pin` [bool]: Pin this object when adding. Required: no.
  - `quiet` [bool]: Write minimal output. Required: no.


#### Request Body

Argument "data" is of file type. This endpoint expects a file in the body of the request as 'multipart/form-data'.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Hash": "<string>",
  "Links": [
    {
      "Hash": "<string>",
      "Name": "<string>",
      "Size": "<uint64>"
    }
  ]
}

```

#### cURL Example

`curl -F file=@myfile "http://localhost:5001/api/v0/object/put?inputenc=json&datafieldenc=text&pin=<value>&quiet=<value>"`

***

### /api/v0/object/stat

Get stats for the DAG node named by <key>.


#### Arguments

  - `arg` [string]: Key of the object to retrieve, in base58-encoded multihash format. Required: **yes**.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "BlockSize": "<int>",
  "CumulativeSize": "<int>",
  "DataSize": "<int>",
  "Hash": "<string>",
  "LinksSize": "<int>",
  "NumLinks": "<int>"
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/object/stat?arg=<key>"`

***

### /api/v0/p2p/close

Stop listening for new connections to forward.


#### Arguments

  - `all` [bool]: Close all listeners. Required: no.
  - `protocol` [string]: Match protocol name. Required: no.
  - `listen-address` [string]: Match listen address. Required: no.
  - `target-address` [string]: Match target address. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
"<int>"

```

#### cURL Example

`curl "http://localhost:5001/api/v0/p2p/close?all=<value>&protocol=<value>&listen-address=<value>&target-address=<value>"`

***

### /api/v0/p2p/forward

Forward connections to libp2p service


#### Arguments

  - `arg` [string]: Protocol name. Required: **yes**.
  - `arg` [string]: Listening endpoint. Required: **yes**.
  - `arg` [string]: Target endpoint. Required: **yes**.
  - `allow-custom-protocol` [bool]: Don't require /x/ prefix. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
This endpoint returns a `text/plain` response body.
```

#### cURL Example

`curl "http://localhost:5001/api/v0/p2p/forward?arg=<protocol>&arg=<listen-address>&arg=<target-address>&allow-custom-protocol=<value>"`

***

### /api/v0/p2p/listen

Create libp2p service


#### Arguments

  - `arg` [string]: Protocol name. Required: **yes**.
  - `arg` [string]: Target endpoint. Required: **yes**.
  - `allow-custom-protocol` [bool]: Don't require /x/ prefix. Required: no.
  - `report-peer-id` [bool]: Send remote base58 peerid to target when a new connection is established. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
This endpoint returns a `text/plain` response body.
```

#### cURL Example

`curl "http://localhost:5001/api/v0/p2p/listen?arg=<protocol>&arg=<target-address>&allow-custom-protocol=<value>&report-peer-id=<value>"`

***

### /api/v0/p2p/ls

List active p2p listeners.


#### Arguments

  - `headers` [bool]: Print table headers (Protocol, Listen, Target). Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Listeners": [
    {
      "ListenAddress": "<string>",
      "Protocol": "<string>",
      "TargetAddress": "<string>"
    }
  ]
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/p2p/ls?headers=<value>"`

***

### /api/v0/p2p/stream/close

Close active p2p stream.


#### Arguments

  - `arg` [string]: Stream identifier Required: no.
  - `all` [bool]: Close all streams. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
This endpoint returns a `text/plain` response body.
```

#### cURL Example

`curl "http://localhost:5001/api/v0/p2p/stream/close?arg=<id>&all=<value>"`

***

### /api/v0/p2p/stream/ls

List active p2p streams.


#### Arguments

  - `headers` [bool]: Print table headers (ID, Protocol, Local, Remote). Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Streams": [
    {
      "HandlerID": "<string>",
      "OriginAddress": "<string>",
      "Protocol": "<string>",
      "TargetAddress": "<string>"
    }
  ]
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/p2p/stream/ls?headers=<value>"`

***

### /api/v0/pin/add

Pin objects to local storage.


#### Arguments

  - `arg` [string]: Path to object(s) to be pinned. Required: **yes**.
  - `recursive` [bool]: Recursively pin the object linked to by the specified object(s). Default: "true". Required: no.
  - `progress` [bool]: Show progress. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Pins": [
    "<string>"
  ],
  "Progress": "<int>"
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/pin/add?arg=<ipfs-path>&recursive=true&progress=<value>"`

***

### /api/v0/pin/ls

List objects pinned to local storage.


#### Arguments

  - `arg` [string]: Path to object(s) to be listed. Required: no.
  - `type` [string]: The type of pinned keys to list. Can be "direct", "indirect", "recursive", or "all". Default: "all". Required: no.
  - `quiet` [bool]: Write just hashes of objects. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Keys": {
    "<string>": {
      "Type": "<string>"
    }
  }
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/pin/ls?arg=<ipfs-path>&type=all&quiet=<value>"`

***

### /api/v0/pin/rm

Remove pinned objects from local storage.


#### Arguments

  - `arg` [string]: Path to object(s) to be unpinned. Required: **yes**.
  - `recursive` [bool]: Recursively unpin the object linked to by the specified object(s). Default: "true". Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Pins": [
    "<string>"
  ]
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/pin/rm?arg=<ipfs-path>&recursive=true"`

***

### /api/v0/pin/update

Update a recursive pin


#### Arguments

  - `arg` [string]: Path to old object. Required: **yes**.
  - `arg` [string]: Path to new object to be pinned. Required: **yes**.
  - `unpin` [bool]: Remove the old pin. Default: "true". Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Pins": [
    "<string>"
  ]
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/pin/update?arg=<from-path>&arg=<to-path>&unpin=true"`

***

### /api/v0/pin/verify

Verify that recursive pins are complete.


#### Arguments

  - `verbose` [bool]: Also write the hashes of non-broken pins. Required: no.
  - `quiet` [bool]: Write just hashes of broken pins. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Cid": "<string>",
  "PinStatus": {
    "BadNodes": [
      {
        "Cid": "<string>",
        "Err": "<string>"
      }
    ],
    "Ok": "<bool>"
  }
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/pin/verify?verbose=<value>&quiet=<value>"`

***

### /api/v0/ping

Send echo request packets to IPFS hosts.


#### Arguments

  - `arg` [string]: ID of peer to be pinged. Required: **yes**.
  - `count` [int]: Number of ping messages to send. Default: "10". Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Success": "<bool>",
  "Text": "<string>",
  "Time": "<duration-ns>"
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/ping?arg=<peer ID>&count=10"`

***

### /api/v0/pubsub/ls

List subscribed topics by name.


#### Arguments

This endpoint takes no arguments.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Strings": [
    "<string>"
  ]
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/pubsub/ls"`

***

### /api/v0/pubsub/peers

List peers we are currently pubsubbing with.


#### Arguments

  - `arg` [string]: topic to list connected peers of Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Strings": [
    "<string>"
  ]
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/pubsub/peers?arg=<topic>"`

***

### /api/v0/pubsub/pub

Publish a message to a given pubsub topic.


#### Arguments

  - `arg` [string]: Topic to publish to. Required: **yes**.
  - `arg` [string]: Payload of message to publish. Required: **yes**.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
This endpoint returns a `text/plain` response body.
```

#### cURL Example

`curl "http://localhost:5001/api/v0/pubsub/pub?arg=<topic>&arg=<data>"`

***

### /api/v0/pubsub/sub

Subscribe to messages on a given topic.


#### Arguments

  - `arg` [string]: String name of topic to subscribe to. Required: **yes**.
  - `discover` [bool]: try to discover other peers subscribed to the same topic. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "data": "<base64-string>",
  "from": "<base64-string>",
  "seqno": "<base64-string>",
  "topicIDs": [
    "<string>"
  ]
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/pubsub/sub?arg=<topic>&discover=<value>"`

***

### /api/v0/refs

List links (references) from an object.


#### Arguments

  - `arg` [string]: Path to the object(s) to list refs from. Required: **yes**.
  - `format` [string]: Emit edges with given format. Available tokens: <src> <dst> <linkname>. Default: <dst>. Default: "<dst>". Required: no.
  - `edges` [bool]: Emit edge format: `<from> -> <to>`. Required: no.
  - `unique` [bool]: Omit duplicate refs from output. Required: no.
  - `recursive` [bool]: Recursively list links of child nodes. Required: no.
  - `max-depth` [int]: Only for recursive refs, limits fetch and listing to the given depth. Default: "-1". Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Err": "<string>",
  "Ref": "<string>"
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/refs?arg=<ipfs-path>&format=<dst>&edges=<value>&unique=<value>&recursive=<value>&max-depth=-1"`

***

### /api/v0/refs/local

List all local references.


#### Arguments

This endpoint takes no arguments.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Err": "<string>",
  "Ref": "<string>"
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/refs/local"`

***

### /api/v0/repo/fsck

Remove repo lockfiles.


#### Arguments

This endpoint takes no arguments.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Message": "<string>"
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/repo/fsck"`

***

### /api/v0/repo/gc

Perform a garbage collection sweep on the repo.


#### Arguments

  - `stream-errors` [bool]: Stream errors. Required: no.
  - `quiet` [bool]: Write minimal output. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Error": "<string>",
  "Key": {
    "/": "<cid-string>"
  }
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/repo/gc?stream-errors=<value>&quiet=<value>"`

***

### /api/v0/repo/stat

Get stats for the currently used repo.


#### Arguments

  - `size-only` [bool]: Only report RepoSize and StorageMax. Required: no.
  - `human` [bool]: Print sizes in human readable format (e.g., 1K 234M 2G). Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "NumObjects": "<uint64>",
  "RepoPath": "<string>",
  "SizeStat": {
    "RepoSize": "<uint64>",
    "StorageMax": "<uint64>"
  },
  "Version": "<string>"
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/repo/stat?size-only=<value>&human=<value>"`

***

### /api/v0/repo/verify

Verify all blocks in repo are not corrupted.


#### Arguments

This endpoint takes no arguments.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Msg": "<string>",
  "Progress": "<int>"
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/repo/verify"`

***

### /api/v0/repo/version

Show the repo version.


#### Arguments

  - `quiet` [bool]: Write minimal output. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Version": "<string>"
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/repo/version?quiet=<value>"`

***

### /api/v0/resolve

Resolve the value of names to IPFS.


#### Arguments

  - `arg` [string]: The name to resolve. Required: **yes**.
  - `recursive` [bool]: Resolve until the result is an IPFS name. Default: "true". Required: no.
  - `dht-record-count` [int]: Number of records to request for DHT resolution. Required: no.
  - `dht-timeout` [string]: Max time to collect values during DHT resolution eg "30s". Pass 0 for no timeout. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Path": "<string>"
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/resolve?arg=<name>&recursive=true&dht-record-count=<value>&dht-timeout=<value>"`

***

### /api/v0/shutdown

Shut down the ipfs daemon


#### Arguments

This endpoint takes no arguments.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
This endpoint returns a `text/plain` response body.
```

#### cURL Example

`curl "http://localhost:5001/api/v0/shutdown"`

***

### /api/v0/stats/bitswap

Show some diagnostic information on the bitswap agent.


#### Arguments

  - `verbose` [bool]: Print extra information. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "BlocksReceived": "<uint64>",
  "BlocksSent": "<uint64>",
  "DataReceived": "<uint64>",
  "DataSent": "<uint64>",
  "DupBlksReceived": "<uint64>",
  "DupDataReceived": "<uint64>",
  "MessagesReceived": "<uint64>",
  "Peers": [
    "<string>"
  ],
  "ProvideBufLen": "<int>",
  "Wantlist": [
    {
      "/": "<cid-string>"
    }
  ]
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/stats/bitswap?verbose=<value>"`

***

### /api/v0/stats/bw

Print ipfs bandwidth information.


#### Arguments

  - `peer` [string]: Specify a peer to print bandwidth for. Required: no.
  - `proto` [string]: Specify a protocol to print bandwidth for. Required: no.
  - `poll` [bool]: Print bandwidth at an interval. Required: no.
  - `interval` [string]: Time interval to wait between updating output, if 'poll' is true.

    This accepts durations such as "300s", "1.5h" or "2h45m". Valid time units are:
    "ns", "us" (or "µs"), "ms", "s", "m", "h". Default: "1s". Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "RateIn": "<float64>",
  "RateOut": "<float64>",
  "TotalIn": "<int64>",
  "TotalOut": "<int64>"
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/stats/bw?peer=<value>&proto=<value>&poll=<value>&interval=1s"`

***

### /api/v0/stats/repo

Get stats for the currently used repo.


#### Arguments

  - `size-only` [bool]: Only report RepoSize and StorageMax. Required: no.
  - `human` [bool]: Print sizes in human readable format (e.g., 1K 234M 2G). Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "NumObjects": "<uint64>",
  "RepoPath": "<string>",
  "SizeStat": {
    "RepoSize": "<uint64>",
    "StorageMax": "<uint64>"
  },
  "Version": "<string>"
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/stats/repo?size-only=<value>&human=<value>"`

***

### /api/v0/swarm/addrs

List known addresses. Useful for debugging.


#### Arguments

This endpoint takes no arguments.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Addrs": {
    "<string>": [
      "<string>"
    ]
  }
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/swarm/addrs"`

***

### /api/v0/swarm/addrs/listen

List interface listening addresses.


#### Arguments

This endpoint takes no arguments.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Strings": [
    "<string>"
  ]
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/swarm/addrs/listen"`

***

### /api/v0/swarm/addrs/local

List local addresses.


#### Arguments

  - `id` [bool]: Show peer ID in addresses. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Strings": [
    "<string>"
  ]
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/swarm/addrs/local?id=<value>"`

***

### /api/v0/swarm/connect

Open connection to a given address.


#### Arguments

  - `arg` [string]: Address of peer to connect to. Required: **yes**.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Strings": [
    "<string>"
  ]
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/swarm/connect?arg=<address>"`

***

### /api/v0/swarm/disconnect

Close connection to a given address.


#### Arguments

  - `arg` [string]: Address of peer to disconnect from. Required: **yes**.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Strings": [
    "<string>"
  ]
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/swarm/disconnect?arg=<address>"`

***

### /api/v0/swarm/filters

Manipulate address filters.


#### Arguments

This endpoint takes no arguments.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Strings": [
    "<string>"
  ]
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/swarm/filters"`

***

### /api/v0/swarm/filters/add

Add an address filter.


#### Arguments

  - `arg` [string]: Multiaddr to filter. Required: **yes**.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Strings": [
    "<string>"
  ]
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/swarm/filters/add?arg=<address>"`

***

### /api/v0/swarm/filters/rm

Remove an address filter.


#### Arguments

  - `arg` [string]: Multiaddr filter to remove. Required: **yes**.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Strings": [
    "<string>"
  ]
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/swarm/filters/rm?arg=<address>"`

***

### /api/v0/swarm/peers

List peers with open connections.


#### Arguments

  - `verbose` [bool]: display all extra information. Required: no.
  - `streams` [bool]: Also list information about open streams for each peer. Required: no.
  - `latency` [bool]: Also list information about latency to each peer. Required: no.
  - `direction` [bool]: Also list information about the direction of connection. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Peers": [
    {
      "Addr": "<string>",
      "Direction": "<int>",
      "Latency": "<string>",
      "Muxer": "<string>",
      "Peer": "<string>",
      "Streams": [
        {
          "Protocol": "<string>"
        }
      ]
    }
  ]
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/swarm/peers?verbose=<value>&streams=<value>&latency=<value>&direction=<value>"`

***

### /api/v0/tar/add

Import a tar file into ipfs.


#### Arguments

  - `arg` [file]: Tar file to add. Required: **yes**.


#### Request Body

Argument "file" is of file type. This endpoint expects a file in the body of the request as 'multipart/form-data'.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Bytes": "<int64>",
  "Hash": "<string>",
  "Name": "<string>",
  "Size": "<string>"
}

```

#### cURL Example

`curl -F file=@myfile "http://localhost:5001/api/v0/tar/add"`

***

### /api/v0/tar/cat

Export a tar file from IPFS.


#### Arguments

  - `arg` [string]: ipfs path of archive to export. Required: **yes**.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
This endpoint returns a `text/plain` response body.
```

#### cURL Example

`curl "http://localhost:5001/api/v0/tar/cat?arg=<path>"`

***

### /api/v0/update




#### Arguments

  - `arg` [string]: Arguments for subcommand. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
This endpoint returns a `text/plain` response body.
```

#### cURL Example

`curl "http://localhost:5001/api/v0/update?arg=<args>"`

***

### /api/v0/urlstore/add

Add URL via urlstore.


#### Arguments

  - `arg` [string]: URL to add to IPFS Required: **yes**.
  - `trickle` [bool]: Use trickle-dag format for dag generation. Required: no.
  - `pin` [bool]: Pin this object when adding. Default: "true". Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Key": "<string>",
  "Size": "<int>"
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/urlstore/add?arg=<url>&trickle=<value>&pin=true"`

***

### /api/v0/version

Show ipfs version information.


#### Arguments

  - `number` [bool]: Only show the version number. Required: no.
  - `commit` [bool]: Show the commit hash. Required: no.
  - `repo` [bool]: Show repo version. Required: no.
  - `all` [bool]: Show all version information. Required: no.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Commit": "<string>",
  "Golang": "<string>",
  "Repo": "<string>",
  "System": "<string>",
  "Version": "<string>"
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/version?number=<value>&commit=<value>&repo=<value>&all=<value>"`

***

### /api/v0/version/deps

Shows information about dependencies used for build


#### Arguments

This endpoint takes no arguments.


#### Response

On success, the call to this endpoint will return with 200 and the following body:

```json
{
  "Path": "<string>",
  "ReplacedBy": "<string>",
  "Sum": "<string>",
  "Version": "<string>"
}

```

#### cURL Example

`curl "http://localhost:5001/api/v0/version/deps"`

***



</details>